### PR TITLE
Make osmnx samples usable with Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OSMnx Examples
 
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jaakla/osmnx-examples/master)
+
 All of the examples are in this repo's [notebooks](notebooks) folder.
 
 OSMnx is a Python package to work with street networks: retrieve, construct,

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - osmnx


### PR DESCRIPTION
Possible fix for https://github.com/gboeing/osmnx/issues/182 

The "Binder" badge in readme should be adjusted for the main repo URL.