### PR TITLE
add required attribution for explores using CartoDB darkmatter tiles

### DIFF
--- a/notebooks/11-interactive-web-mapping.ipynb
+++ b/notebooks/11-interactive-web-mapping.ipynb
@@ -96,7 +96,7 @@
    "source": [
     "# explore nodes and edges together in a single map\n",
     "nodes, edges = ox.graph_to_gdfs(G)\n",
-    "m = edges.explore(color=\"skyblue\", tiles=\"cartodbdarkmatter\")\n",
+    "m = edges.explore(color=\"skyblue\", tiles=\"cartodbdarkmatter\", attr=\"CartoDB\")\n",
     "nodes.explore(m=m, color=\"pink\", marker_kwds={\"radius\": 6})"
    ]
   },
@@ -114,7 +114,7 @@
    "outputs": [],
    "source": [
     "# explore graph edges interactively, colored by length\n",
-    "edges.explore(tiles=\"cartodbdarkmatter\", column=\"length\", cmap=\"plasma\")"
+    "edges.explore(tiles=\"cartodbdarkmatter\", column=\"length\", cmap=\"plasma\", attr=\"CartoDB\")"
    ]
   },
   {
@@ -126,7 +126,7 @@
     "# explore graph nodes interactively, colored by betweenness centrality\n",
     "nx.set_node_attributes(G, nx.betweenness_centrality(G, weight=\"length\"), name=\"bc\")\n",
     "nodes = ox.graph_to_gdfs(G, edges=False)\n",
-    "nodes.explore(tiles=\"cartodbdarkmatter\", column=\"bc\", marker_kwds={\"radius\": 8})"
+    "nodes.explore(tiles=\"cartodbdarkmatter\", column=\"bc\", marker_kwds={\"radius\": 8}, attr=\"CartoDB\")"
    ]
   },
   {
@@ -158,8 +158,8 @@
    "outputs": [],
    "source": [
     "# explore graph edges and route together in a single map\n",
-    "m = edges.explore(color=\"maroon\", tiles=\"cartodbdarkmatter\")\n",
-    "m = route_edges.explore(m=m, color=\"yellow\", style_kwds={\"weight\": 5})\n",
+    "m = edges.explore(color=\"maroon\", tiles=\"cartodbdarkmatter\", attr=\"CartoDB\")\n",
+    "m = route_edges.explore(m=m, color=\"yellow\", style_kwds={\"weight\": 5}, attr=\"CartoDB\")\n",
     "m"
    ]
   },
@@ -172,7 +172,7 @@
     "# or explore multiple routes together in a single map\n",
     "routes = ox.k_shortest_paths(G, orig, dest, k=200, weight=weight)\n",
     "gdfs = (ox.utils_graph.route_to_gdf(G, route, weight=weight) for route in routes)\n",
-    "m = edges.explore(color=\"#222222\", tiles=\"cartodbdarkmatter\")\n",
+    "m = edges.explore(color=\"#222222\", tiles=\"cartodbdarkmatter\", attr=\"CartoDB\")\n",
     "for route_edges in gdfs:\n",
     "    m = route_edges.explore(m=m, color=\"cyan\", style_kwds={\"weight\": 5, \"opacity\": 0.05})\n",
     "m"
@@ -205,11 +205,11 @@
    "source": [
     "# explore a city's bus stops and rail transit interactively\n",
     "bus = ox.features_from_place(place, tags={\"highway\": \"bus_stop\"})\n",
-    "m = bus.explore(tiles=tiles, color=\"red\", tooltip=\"name\", marker_kwds=mk)\n",
+    "m = bus.explore(tiles=tiles, color=\"red\", tooltip=\"name\", marker_kwds=mk, attr=\"CartoDB\")\n",
     "rail = ox.features_from_place(place, tags={\"railway\": \"light_rail\"})\n",
-    "m = rail.explore(m=m, tiles=tiles, color=\"yellow\", tooltip=\"name\")\n",
+    "m = rail.explore(m=m, tiles=tiles, color=\"yellow\", tooltip=\"name\", attr=\"CartoDB\")\n",
     "stations = ox.features_from_place(place, tags={\"railway\": \"station\"})\n",
-    "stations.explore(m=m, tiles=tiles, color=\"yellow\", tooltip=\"name\", marker_kwds=mk)"
+    "stations.explore(m=m, tiles=tiles, color=\"yellow\", tooltip=\"name\", marker_kwds=mk, attr=\"CartoDB\")"
    ]
   },
   {
@@ -220,7 +220,7 @@
    "source": [
     "# explore a city's parks interactively\n",
     "parks = ox.features_from_place(place, tags={\"leisure\": \"park\"})\n",
-    "parks.explore(tiles=tiles, color=\"lime\", tooltip=\"name\")"
+    "parks.explore(tiles=tiles, color=\"lime\", tooltip=\"name\", attr=\"CartoDB\")"
    ]
   },
   {
@@ -232,7 +232,7 @@
     "# explore a neighborhood's buildings interactively\n",
     "gdf = ox.features_from_place(\"SoHo, New York, NY\", tags={\"building\": True})\n",
     "cols = [\"height\", \"addr:housenumber\", \"addr:street\", \"addr:postcode\"]\n",
-    "gdf.explore(tiles=\"cartodbdarkmatter\", tooltip=cols)"
+    "gdf.explore(tiles=\"cartodbdarkmatter\", tooltip=cols, attr=\"CartoDB\")"
    ]
   },
   {
@@ -246,7 +246,7 @@
     "cols = [\"height\", \"addr:housenumber\", \"addr:street\", \"addr:postcode\"]\n",
     "G = ox.graph_from_place(place, network_type=\"drive\", truncate_by_edge=True)\n",
     "gdf = ox.features_from_place(place, tags={\"building\": True})\n",
-    "m = gdf.explore(tiles=tiles, tooltip=cols)\n",
+    "m = gdf.explore(tiles=tiles, tooltip=cols, attr=\"CartoDB\")\n",
     "ox.graph_to_gdfs(G, nodes=False).explore(m=m, color=\"yellow\")"
    ]
   },


### PR DESCRIPTION
Currently, executing many of the examples in "11-interactive-web-mapping notebook with required attribution" yields
this error: "ValueError: Custom tiles must have an attribution."

This diff resolves the error by adding the required "attr" param to the explore calls.


