### PR TITLE
add additional custom_filter examples

### DIFF
--- a/notebooks/08-custom-filters-infrastructure.ipynb
+++ b/notebooks/08-custom-filters-infrastructure.ipynb
@@ -140,7 +140,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# get NY subway rail network without any service tagged infrastructure\n",
+    "ox.settings.useful_tags_way += [\"railway\"]\n",
+    "G = ox.graph_from_place(\n",
+    "    \"New York, New York, USA\",\n",
+    "    retain_all=False,\n",
+    "    truncate_by_edge=True,\n",
+    "    simplify=True,\n",
+    "    custom_filter='[\"railway\"~\"subway\"][!\"service\"]',\n",
+    ")\n",
+    "\n",
+    "fig, ax = ox.plot_graph(G, node_size=0, edge_color=\"w\", edge_linewidth=0.2)"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/08-custom-filters-infrastructure.ipynb
+++ b/notebooks/08-custom-filters-infrastructure.ipynb
@@ -119,6 +119,27 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "# get NY subway rail network without yards and sidings\n",
+    "# More documentation available at https://wiki.openstreetmap.org/wiki/Overpass_API/Language_Guide#The_Overpass_API_languages\n",
+    "# under the `Tag request clauses (or \"tag filters\")` section\n",
+    "ox.settings.useful_tags_way += [\"railway\"]\n",
+    "G = ox.graph_from_place(\n",
+    "    \"New York, New York, USA\",\n",
+    "    retain_all=False,\n",
+    "    truncate_by_edge=True,\n",
+    "    simplify=True,\n",
+    "    custom_filter='[\"railway\"~\"subway\"][\"service\"!~\"yard|siding\"]',\n",
+    ")\n",
+    "\n",
+    "fig, ax = ox.plot_graph(G, node_size=0, edge_color=\"w\", edge_linewidth=0.2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],


### PR DESCRIPTION
Added two examples that further demonstrate how to use the custom_filter parameter. These examples should make it easier to understand how to filter out specific feature keys and options.

Examples expand upon the existing New York subway example, and reuses code from this Stack Overflow answer:
https://stackoverflow.com/a/66320085

Also added a link to the relevant Overpass API documentation for additional help.