### PR TITLE
Typo fix for computing travel time and distance

### DIFF
--- a/notebooks/02-routing-speed-time.ipynb
+++ b/notebooks/02-routing-speed-time.ipynb
@@ -227,8 +227,8 @@
    "source": [
     "# compare the two routes\n",
     "route1_length = int(sum(ox.utils_graph.route_to_gdf(G, route1, \"length\")[\"length\"]))\n",
-    "route2_length = int(sum(ox.utils_graph.route_to_gdf(G, route2, \"length\")[\"length\"]))\n",
-    "route1_time = int(sum(ox.utils_graph.route_to_gdf(G, route1, \"travel_time\")[\"travel_time\"]))\n",
+    "route2_length = int(sum(ox.utils_graph.route_to_gdf(G, route2, \"travel_time\")[\"length\"]))\n",
+    "route1_time = int(sum(ox.utils_graph.route_to_gdf(G, route1, \"length\")[\"travel_time\"]))\n",
     "route2_time = int(sum(ox.utils_graph.route_to_gdf(G, route2, \"travel_time\")[\"travel_time\"]))\n",
     "print(\"Route 1 is\", route1_length, \"meters and takes\", route1_time, \"seconds.\")\n",
     "print(\"Route 2 is\", route2_length, \"meters and takes\", route2_time, \"seconds.\")"
@@ -381,9 +381,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (ox)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "ox"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -395,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Typo fix for “02-routing-speed-time.ipynb” under the section “3. Imputing travel speeds and times”