### PR TITLE
rectify default network_type

### DIFF
--- a/notebooks/01-overview-osmnx.ipynb
+++ b/notebooks/01-overview-osmnx.ipynb
@@ -124,8 +124,8 @@
     "  - 'drive_service' - get drivable streets, including service roads\n",
     "  - 'walk' - get all streets and paths that pedestrians can use (this network type ignores one-way directionality)\n",
     "  - 'bike' - get all streets and paths that cyclists can use\n",
-    "  - 'all' - download all non-private OSM streets and paths (this is the default network type unless you specify a different one)\n",
-    "  - 'all_private' - download all OSM streets and paths, including private-access ones"
+    "  - 'all' - download all non-private OSM streets and paths \n",
+    "  - 'all_private' - download all OSM streets and paths, including private-access ones (this is the default network type unless you specify a different one)"
    ]
   },
   {


### PR DESCRIPTION
In the markdown block starting with: ## Part 2: download and model street networks...
You mention that the default network_type is 'all', however according to the osmnx documentation, I see that the default now is 'all_private'. [See](https://osmnx.readthedocs.io/en/stable/user-reference.html#osmnx.graph.graph_from_place).

Hence, this PR is to reflect the same change in the examples. 
